### PR TITLE
Fix typechecking bug for the bare Err term

### DIFF
--- a/typing/bidirect.ml
+++ b/typing/bidirect.ml
@@ -387,7 +387,12 @@ let type_check_group (bctx : built_in_ctx) =
         let () = pprint_typing_check_term rctx (e, rty) in
         match e.x with
         | CVal _ -> _die [%here]
-        | CErr -> Some CErr#:rty
+        | CErr ->
+            if
+              sub_rty_bool uctx
+                (prop_to_rty false (Rty.erase_rty rty) mk_false, rty)
+            then Some CErr#:rty
+            else None
         | CLetDeTuple _ -> failwith "unimp"
         | CApp _ | CAppOp _ | CMatch _ | CLetE _ | CRecord _ | CField _ ->
             let* e' = term_type_infer rctx e in


### PR DESCRIPTION
If you have a program with just an err term as the body, typechecking (incorrectly) always succeeds. This only happens when err is the root ast node of the bidirectional typechecking algorithm(as otherwise we call infer on Err, get a type which is equivalent to false/covering nothing, and this fails during subtyping as expected). 

```ocaml
let rec sized_list_gen (s : int) : int list =
  Err

let[@assert] sized_list_gen =
  let s = (0 <= v : [%v: int]) [@over] in
  (emp v : [%v: int list]) [@under]
```