### PR TITLE
Fix incorrect uniqueness axiom

### DIFF
--- a/data/predefined/axioms_bak.ml
+++ b/data/predefined/axioms_bak.ml
@@ -66,7 +66,7 @@ let[@axiom] list_tl_unique (l : int list) (l1 : int list) =
   (tl l l1 && uniq l) #==> (uniq l1)
 
 let[@axiom] list_hd_unique (l : int list) (l1 : int list) (x : int) =
-  (tl l l1 && uniq l && hd l1 x) #==> (not (list_mem l1 x))
+  (tl l l1 && uniq l && hd l x) #==> (not (list_mem l1 x))
 
 (** int tree *)
 


### PR DESCRIPTION
Not sure if `axioms_bak.ml` is still being used in the main project, but while using these axioms for testing another tool I noticed one of them was incorrect 😅 (`hd l1 x` actually *should* imply `list_mem l1 x`; rather I believe it should say that the head of the parent list `l` is not contained in the tail `l1`)