### PR TITLE
Update statistics to return 0 if no tasks were run

### DIFF
--- a/auxtyping/subrty.ml
+++ b/auxtyping/subrty.ml
@@ -37,11 +37,11 @@ let rec sub_rty rctx (rty1, rty2) =
         _failatwith [%here]
           (spf "die: %s <: %s" (layout_rty rty1) (layout_rty rty2))
   in
-  let () = Statistic.stat_count_qeury rctx.task_name in
+  let () = Statistic.stat_count_query rctx.task_name in
   aux rctx (rty1, rty2)
 
 let non_emptiness_rty rctx rty =
-  let () = Statistic.stat_count_qeury rctx.task_name in
+  let () = Statistic.stat_count_query rctx.task_name in
   match rty with
   | RtyBase { ou = Under; cty } -> non_emptiness_cty rctx cty
   | RtyArr _ -> true

--- a/data/simple/ReturnError.ml
+++ b/data/simple/ReturnError.ml
@@ -1,0 +1,5 @@
+let rec sized_list_gen (s : int) : int list = Err
+
+let[@assert] sized_list_gen =
+  let s = ((0 <= v : [%v: int]) [@over]) in
+  ((true : [%v: int list]) [@under])

--- a/statistic/statistic.ml
+++ b/statistic/statistic.ml
@@ -33,7 +33,7 @@ let update_stat name f =
 let stat_update_rty (name, (num_qt, num_qpred)) =
   update_stat name (fun stat -> { stat with num_qt; num_qpred })
 
-let stat_count_qeury name =
+let stat_count_query name =
   update_stat name (fun stat -> { stat with num_query = stat.num_query + 1 })
 
 let stat_query_time (name, time) =
@@ -57,7 +57,10 @@ let stat_total_time (name, total_time) =
 let calcutale_stat stat =
   (* let num_query = List.length stat.query_times in *)
   (* let query_time = List.fold_left ( +. ) 0.0 stat.query_times in *)
-  let avg_time = stat.total_time /. float_of_int stat.num_query in
+  let avg_time =
+    if stat.num_query = 0 then 0.
+    else stat.total_time /. float_of_int stat.num_query
+  in
   let mp = List.length stat.method_prdicates in
   { stat with avg_time; mp }
 

--- a/typing/bidirect.ml
+++ b/typing/bidirect.ml
@@ -388,8 +388,8 @@ let type_check_group (bctx : built_in_ctx) =
         match e.x with
         | CVal _ -> _die [%here]
         | CErr ->
-            if sub_rty rctx (mk_bot_underrty (erase_rty rty), rty)
-            then Some CErr#:rty
+            if sub_rty rctx (mk_bot_underrty (erase_rty rty), rty) then
+              Some CErr#:rty
             else None
         | CLetDeTuple _ -> failwith "unimp"
         | CApp _ | CAppOp _ | CMatch _ | CLetE _ | CRecord _ | CField _ ->


### PR DESCRIPTION
If no queries to Z3 are made in a given task, then it computes positive infinity for the average per query, which can't be serialized into JSON. This changes it to return 0 in that case.

This also adds a file for testing the previous fix for returning Err directly, and running the type checker should fail on that case. I'm currently working on adding better testing support (`dune test` should run some specified examples in `data/` and check that the expected tests passed or failed), but this is still a WIP.