### PR TITLE
Nonemptiness tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
       - if: steps.opam-cache.outputs.cache-hit != 'true'
         run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
-      - run: opam exec -- dune test test/fast test/slow
+      - run: opam exec -- dune test test/fast test/slow test/nonempty.ml

--- a/auxtyping/subcty.ml
+++ b/auxtyping/subcty.ml
@@ -22,8 +22,6 @@ let smart_dependent_forall (x, { nty; phi }) query =
 
 let smart_dependent_exists (x, { nty; phi }) query =
   let phi = subst_prop_instance default_v (AVar x#:nty) phi in
-  (* let query = fresh_name_prop query in *)
-  (* Exists { qv = x#:nty; body = smart_add_to phi query } *)
   smart_exists_phi (x#:nty, phi) query
 
 let report_unclosed loc query =
@@ -156,7 +154,6 @@ let non_emptiness_cty rctx cty =
   if lazy_emptiness_check then true
   else
     let overctx, underctx = build_wf_ctx (Typectx.ctx_to_list rctx.rty_ctx) in
-    let underctx = underctx @ [ (default_v, mk_top_cty cty.nty) ] in
     let () =
       _log_auxtyping @@ fun _ ->
       let overctx =
@@ -174,28 +171,25 @@ let non_emptiness_cty rctx cty =
         "left-hand-side type should be closed under over + under ctx"
         (is_close_cty (List.map fst (overctx @ underctx)) cty)
     in
-    let overctx = (default_v, mk_top_cty cty.nty) :: overctx in
+    let { nty; phi } = cty in
     let query =
-      List.fold_right smart_dependent_exists (overctx @ underctx) cty.phi
+      smart_implies phi Prop.mk_false
+      |> smart_dependent_forall (default_v, mk_top_cty nty)
+      |> List.fold_right smart_dependent_exists underctx
+      |> List.fold_right smart_dependent_forall overctx
     in
     let () = Statistic.stat_query_formula (rctx.task_name, query) in
     let time, res =
       clock (fun () ->
           let () =
             _log_auxtyping @@ fun _ ->
-            Printf.printf "check sat: %s\n" (layout_prop_ query)
+            Printf.printf "check valid: %s\n" (layout_prop_ query)
           in
           let () =
             _log_auxtyping @@ fun _ ->
             Printf.printf "let[@axiom] tmp = %s\n" (layout_prop__raw query)
           in
-          Prover.check_sat (Some rctx.task_name, query))
+          Prover.check_valid (Some rctx.task_name, query))
     in
     let () = Statistic.stat_query_time (rctx.task_name, time) in
-    let res =
-      match res with SmtUnsat -> false | SmtSat _ -> true | Timeout -> true
-      (* NOTE: we cannot decide if this control flow is unreachable, thus continue *)
-    in
-    (* let () = if List.length underctx > 1 then _die [%here] in *)
-    (* let () = if not res then _die [%here] in *)
-    res
+    not res

--- a/statistic/statistic.ml
+++ b/statistic/statistic.ml
@@ -3,6 +3,8 @@ open Language
 open Zutils
 open Zdatatype
 
+type 'a ht_result = Value of 'a | Ignored | Missing
+
 type stat = {
   function_name : string;
   branchs : int;
@@ -25,10 +27,22 @@ type stat_list = stat list [@@deriving eq, ord, show, sexp, yojson]
 
 let _stat_tab = Hashtbl.create 20
 
-let update_stat name f =
+let find_stat name =
   match Hashtbl.find_opt _stat_tab name with
-  | Some stat -> Hashtbl.replace _stat_tab name (f stat)
-  | None -> _die [%here]
+  | Some (Some stat) -> Value stat
+  | Some None -> Ignored
+  | None -> Missing
+
+let insert_stat name stat =
+  match find_stat name with
+  | Missing -> Hashtbl.add _stat_tab name stat
+  | _ -> _die_with [%here] (spf "creating duplicate stat %s" name)
+
+let update_stat name f =
+  match find_stat name with
+  | Value stat -> Hashtbl.replace _stat_tab name (Some (f stat))
+  | Ignored -> ()
+  | Missing -> _die [%here]
 
 let stat_update_rty (name, (num_qt, num_qpred)) =
   update_stat name (fun stat -> { stat with num_qt; num_qpred })
@@ -67,6 +81,7 @@ let calculate_stat stat =
 let store_stat filename =
   let j =
     stat_list_to_yojson @@ List.map calculate_stat @@ List.of_seq
+    @@ Seq.filter_map Fun.id
     @@ Hashtbl.to_seq_values _stat_tab
   in
   Yojson.Safe.to_file filename j
@@ -94,9 +109,7 @@ let create_stat function_name (imp : (Nt.t, Nt.t term) typed) =
       avg_time = 0.0;
     }
   in
-  match Hashtbl.find_opt _stat_tab function_name with
-  | None -> Hashtbl.add _stat_tab function_name stat
-  | Some _ -> _die [%here]
+  insert_stat function_name (Some stat)
 
 let create_subtyping_stat () =
   let function_name = "subtyping" in
@@ -119,8 +132,7 @@ let create_subtyping_stat () =
       avg_time = 0.0;
     }
   in
-  match Hashtbl.find_opt _stat_tab function_name with
-  | None -> Hashtbl.add _stat_tab function_name stat
-  | Some _ -> _die [%here]
+  insert_stat function_name (Some stat)
 
+let create_ignored_stat name = insert_stat name None
 let clear () = Hashtbl.clear _stat_tab

--- a/test/dune
+++ b/test/dune
@@ -1,2 +1,6 @@
 (library
-  (name test_CoverageType))
+  (name test_CoverageType)
+  (libraries auxtyping preprocess typing)
+  (modules nonempty)
+  (inline_tests)
+  (preprocess (pps ppx_inline_test)))

--- a/test/dune
+++ b/test/dune
@@ -3,4 +3,4 @@
   (libraries auxtyping preprocess typing)
   (modules nonempty)
   (inline_tests)
-  (preprocess (pps ppx_inline_test)))
+  (preprocess (pps ppx_here ppx_inline_test)))

--- a/test/dune
+++ b/test/dune
@@ -2,5 +2,7 @@
   (name test_CoverageType)
   (libraries auxtyping preprocess typing)
   (modules nonempty)
-  (inline_tests)
+  (inline_tests
+    (deps (glob_files_rec ../../data/**)
+          (file ../meta-config.json)))
   (preprocess (pps ppx_here ppx_inline_test)))

--- a/test/nonempty.ml
+++ b/test/nonempty.ml
@@ -1,0 +1,25 @@
+open Auxtyping
+open Typing
+open Language
+
+let is_nonempty_rty name rctx rty =
+  Statistic.clear ();
+  Statistic.create_ignored_stat name;
+  let root = Sys.getenv "DUNE_SOURCEROOT" in
+  Sys.chdir root;
+  Myconfig.meta_config_path := "test/meta-config.json";
+  non_emptiness_rty rctx rty
+
+let%test "[v: int | true]" =
+  let test_name = "test" in
+  let rctx = Rctx.emp test_name [] [] in
+  let cty = { nty = Nt.int_ty; phi = Prop.mk_true } in
+  let rty = RtyBase { ou = Under; cty } in
+  is_nonempty_rty test_name rctx rty
+
+let%test "[v: int | false]" =
+  let test_name = "test" in
+  let rctx = Rctx.emp test_name [] [] in
+  let cty = { nty = Nt.int_ty; phi = Prop.mk_false } in
+  let rty = RtyBase { ou = Under; cty } in
+  not @@ is_nonempty_rty test_name rctx rty

--- a/test/nonempty.ml
+++ b/test/nonempty.ml
@@ -76,3 +76,26 @@ let%test "[v:bool | v == (size == 0)]" =
   in
   let rctx = Rctx.add_var rctx "size"#:size_rty in
   is_nonempty_rty test_name rctx goal_rty
+
+let%test "[v:bool | v == (x > 0)]" =
+  let open Nt in
+  let test_name = "test" in
+  let rctx = Rctx.emp test_name [] [] in
+  let x_rty =
+    let phi = Lit (AC (B true))#:bool_ty in
+    RtyBase { ou = Under; cty = { nty = int_ty; phi } }
+  in
+  let goal_rty =
+    let v_bool = (AVar default_v#:bool_ty)#:bool_ty in
+    let x = (AVar "x"#:int_ty)#:int_ty in
+    let int_int_bool_ty = mk_long_arr [ int_ty; int_ty; bool_ty ] in
+    let bool_bool_bool_ty = mk_long_arr [ bool_ty; bool_ty; bool_ty ] in
+    let gr_int = ">"#:int_int_bool_ty in
+    let eq_bool = "=="#:bool_bool_bool_ty in
+    let zero = (AC (I 0))#:int_ty in
+    let inner_eq = (AAppOp (gr_int, [ x; zero ]))#:bool_ty in
+    let phi = Lit (AAppOp (eq_bool, [ v_bool; inner_eq ]))#:bool_ty in
+    RtyBase { ou = Under; cty = { nty = bool_ty; phi } }
+  in
+  let rctx = Rctx.add_var rctx "x"#:x_rty in
+  is_nonempty_rty test_name rctx goal_rty

--- a/test/nonempty.ml
+++ b/test/nonempty.ml
@@ -1,6 +1,30 @@
 open Auxtyping
 open Typing
 open Language
+open Zutils
+
+let check_rty basic_ctx rty =
+  check_wf_rty rty;
+  let _ = Preprocess.rty_type_check basic_ctx [] rty in
+  ()
+
+let construct_basic_ctx rctx =
+  let basic_ctx = Preprocess.load_basic_ctx () in
+  let rctx_list = Typectx.ctx_to_list rctx.rty_ctx in
+  List.fold_left
+    (fun acc { x; ty = rty } ->
+      check_wf_rty rty;
+      let _ = Preprocess.rty_type_check acc [] rty in
+      match rty with
+      | RtyBase { cty = { nty; _ }; _ } -> Typectx.add_to_right acc x#:nty
+      | _ -> acc)
+    basic_ctx rctx_list
+
+let rec mk_long_arr = function
+  | [] ->
+      _die_with [%here] "cannot construct arrow type from empty list of types"
+  | [ ty ] -> ty
+  | ty :: rest -> Nt.mk_arr ty (mk_long_arr rest)
 
 let is_nonempty_rty name rctx rty =
   Statistic.clear ();
@@ -8,6 +32,8 @@ let is_nonempty_rty name rctx rty =
   let root = Sys.getenv "DUNE_SOURCEROOT" in
   Sys.chdir root;
   Myconfig.meta_config_path := "test/meta-config.json";
+  let basic_ctx = construct_basic_ctx rctx in
+  check_rty basic_ctx rty;
   non_emptiness_rty rctx rty
 
 let%test "[v: int | true]" =
@@ -23,3 +49,30 @@ let%test "[v: int | false]" =
   let cty = { nty = Nt.int_ty; phi = Prop.mk_false } in
   let rty = RtyBase { ou = Under; cty } in
   not @@ is_nonempty_rty test_name rctx rty
+
+let%test "[v:bool | v == (size == 0)]" =
+  let open Nt in
+  let test_name = "test" in
+  let rctx = Rctx.emp test_name [] [] in
+  let size_rty =
+    let v_int = (AVar default_v#:int_ty)#:int_ty in
+    let int_int_bool_ty = mk_long_arr [ int_ty; int_ty; bool_ty ] in
+    let geq_func = ">="#:int_int_bool_ty in
+    let zero = (AC (I 0))#:int_ty in
+    let phi = Lit (AAppOp (geq_func, [ v_int; zero ]))#:bool_ty in
+    RtyBase { ou = Over; cty = { nty = int_ty; phi } }
+  in
+  let goal_rty =
+    let v_bool = (AVar default_v#:bool_ty)#:bool_ty in
+    let size = (AVar "size"#:int_ty)#:int_ty in
+    let int_int_bool_ty = mk_long_arr [ int_ty; int_ty; bool_ty ] in
+    let bool_bool_bool_ty = mk_long_arr [ bool_ty; bool_ty; bool_ty ] in
+    let eq_int = "=="#:int_int_bool_ty in
+    let eq_bool = "=="#:bool_bool_bool_ty in
+    let zero = (AC (I 0))#:int_ty in
+    let inner_eq = (AAppOp (eq_int, [ size; zero ]))#:bool_ty in
+    let phi = Lit (AAppOp (eq_bool, [ v_bool; inner_eq ]))#:bool_ty in
+    RtyBase { ou = Under; cty = { nty = bool_ty; phi } }
+  in
+  let rctx = Rctx.add_var rctx "size"#:size_rty in
+  is_nonempty_rty test_name rctx goal_rty


### PR DESCRIPTION
This adds some tests focusing specifically on non-emptiness queries, which I suspect weren't covered well by the current tests since they mostly expect types to be non-empty It's not very ergonomic right now (I'm thinking about reusing the existing parser to create a ppx to write tests similarly to how we write files). One alternative is that we could encode the exact test case as a program, but the exact behavior of the test then depends on the implementation of the bidirectional typing algorithm, while I would like to test this function specifically.

This also modifies the non-emptiness query to more closely match the implementation in the paper. As it is currently written though, the query constructed isn't necessarily decidable, so I am looking to see if there is an equivalent implementation that works.

TODO: add some more tests