### PR TITLE
Fix check_wf and rename to clearer name

### DIFF
--- a/ast/astHelper.ml
+++ b/ast/astHelper.ml
@@ -90,20 +90,22 @@ let is_free_rty x rty = List.exists (String.equal x) @@ fv_rty_id rty
 let is_close_rty dom rty =
   List.for_all (fun x -> List.exists (String.equal x) dom) @@ fv_rty_id rty
 
-let check_wf_rty (tau : 't rty) =
-  let rec aux tau =
-    match tau with
-    | RtyBase _ -> ()
-    | RtyArr { argrty; arg; retty } -> (
-        match argrty with
-        | RtyBase { ou = Over; _ } -> ()
-        | _ ->
-            if is_free_rty arg retty then
-              _die_with [%here] "Rty is not well-fromed")
-    | RtyPolyType { rty; _ } -> aux rty
-    | RtyPolyPred { rty; _ } -> aux rty
-  in
-  aux tau
+let rec check_syntactically_wf_rty = function
+  | RtyBase _ -> ()
+  | RtyArr { argrty; arg; retty } -> (
+      match argrty with
+      | RtyBase { ou = Over; _ } -> check_syntactically_wf_rty retty
+      | RtyArr _ as funcrty ->
+          _assert [%here]
+            "rty not well-formed: function arg cannot be free in return type"
+            (not (is_free_rty arg retty));
+          check_syntactically_wf_rty funcrty;
+          check_syntactically_wf_rty retty
+      | _ ->
+          _die_with [%here]
+            "rty not well-formed: function arg must be over or arrow type")
+  | RtyPolyType { rty; _ } -> check_syntactically_wf_rty rty
+  | RtyPolyPred { rty; _ } -> check_syntactically_wf_rty rty
 
 let constant_to_value c = (VConst c)#:(Prop.constant_to_nt c)
 let value_to_term v = (CVal v)#:v.ty

--- a/frontend_opt/to_rty.ml
+++ b/frontend_opt/to_rty.ml
@@ -68,5 +68,5 @@ let rec rty_of_expr expr =
 
 let rty_of_expr expr =
   let rty = rty_of_expr expr in
-  check_wf_rty rty;
+  check_syntactically_wf_rty rty;
   rty

--- a/preprocess/basic_typing.ml
+++ b/preprocess/basic_typing.ml
@@ -52,7 +52,7 @@ let constraint_rty_type_check (ctx : t ctx) (bc : BC.bc) (rty : t rty) =
 
 let rty_type_check (ctx : t ctx) (poly_vars : string list) (rty : t rty) : t rty
     =
-  let () = check_wf_rty rty in
+  let () = check_syntactically_wf_rty rty in
   let () =
     _log @@ fun _ ->
     pprint_ctx Nt.layout ctx;


### PR DESCRIPTION
It seems like the `check_wf_rty` function wasn't recursively checking function types, so I fixed that and made the logic a bit clearer. I also renamed the function to clarify its only a syntactic check, it doesn't implement the full well-formedness check as described in the paper.